### PR TITLE
Fix/74 Refactor SPI Service Loader to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 The one-stop lib for code generation for kotlin (jvm) and code generation testing. Based on [kotlin-poet](https://square.github.io/kotlinpoet/).
 
-
 [![incubating](https://img.shields.io/badge/lifecycle-INCUBATING-orange.svg)](https://github.com/holisticon#open-source-lifecycle)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.toolisticon.kotlin.generation/kotlin-code-generation/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.toolisticon.kotlin.generation/kotlin-code-generation)
 [![Build Status](https://github.com/toolisticon/kotlin-code-generation/workflows/Development%20branches/badge.svg)](https://github.com/toolisticon/kotlin-code-generation/actions)
@@ -30,7 +29,22 @@ The one-stop lib for code generation for kotlin (jvm) and code generation testin
 
 ## Documentation
 
-* see [kotlin-poet](https://square.github.io/kotlinpoet/) 
+This code generation lib wraps the fantastic [kotlin-poet](https://square.github.io/kotlinpoet/) framework. The documentation is based on the [kotlin-poet documentation](https://square.github.io/kotlinpoet/).
+
+## Getting started
+
+Core concept are [Strategies](./kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationStrategy.kt) and [Processors](./kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationProcessor.kt).
+
+### Load SPI
+
+* Implement and list your strategies and processors in the `META-INF/services/io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpi`. Both interfaces are loaded via the same ServiceLoader mechanism,
+and later filtered for the specific type of strategy or processor.
+* Load the services via `val spi = KotlinCodeGeneration.spi.load()`
+* Define your context by extending the `KotlinCodeGenerationContext` class. This context is passed to the strategies and processors, so they can use more data than just the input item in the loop.
+  * You probably want to filter the loaded list you provide to your specific context.
+  * 
+
+
 
 ## Features
 

--- a/_itest/spi-itest/src/test/kotlin/SpiITest.kt
+++ b/_itest/spi-itest/src/test/kotlin/SpiITest.kt
@@ -3,8 +3,9 @@ package io.toolisticon.kotlin.generation.itest.spi
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.className
-import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.registry
-import io.toolisticon.kotlin.generation.spi.registry.DefaultKotlinCodeGenerationServiceRegistry
+import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.filter.hasContextType
+import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.filter.hasNameIn
+import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationSpiList
 import io.toolisticon.kotlin.generation.spi.strategy.executeSingle
 import io.toolisticon.kotlin.generation.test.KotlinCodeGenerationTest.compile
 import io.toolisticon.kotlin.generation.test.callPrimaryConstructor
@@ -19,19 +20,20 @@ internal class SpiITest {
 
   @Test
   fun `init is empty`() {
-    val registry = registry(
-      contextTypeUpperBound = TestContext::class,
-      exclusions = setOf("io.toolisticon.kotlin.generation.itest.spi.TestDataClassStrategy")
-    )
+    val list = KotlinCodeGenerationSpiList()
+      .filter(hasContextType(TestContext::class))
+      .filterNot(hasNameIn(setOf("io.toolisticon.kotlin.generation.itest.spi.TestDataClassStrategy")))
 
-    assertThat(registry.strategies).isEmpty()
-    assertThat(registry.processors).isEmpty()
+    assertThat(list.strategies).isEmpty()
+    assertThat(list.processors).isEmpty()
   }
 
   @Test
   fun `use spi defined strategies and processors to generate code`() {
-    val list = registry()
-    val context = TestContext(DefaultKotlinCodeGenerationServiceRegistry(list))
+    val registry = KotlinCodeGenerationSpiList(
+      TestDataClassStrategy()
+    ).registry()
+    val context = TestContext(registry)
 
 
     val input = MapInput(

--- a/_itest/spi-itest/src/test/kotlin/SpiITest.kt
+++ b/_itest/spi-itest/src/test/kotlin/SpiITest.kt
@@ -4,13 +4,13 @@ import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.className
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.registry
+import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationServiceRepository
 import io.toolisticon.kotlin.generation.spi.strategy.executeSingle
 import io.toolisticon.kotlin.generation.test.KotlinCodeGenerationTest.compile
 import io.toolisticon.kotlin.generation.test.callPrimaryConstructor
 import io.toolisticon.kotlin.generation.test.model.KotlinCompilationCommand
 import io.toolisticon.kotlin.generation.test.model.requireOk
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 
@@ -18,20 +18,20 @@ import org.junit.jupiter.api.Test
 internal class SpiITest {
 
   @Test
-  fun `init fails when only strategy is excluded`() {
-    assertThatThrownBy {
-      registry(
-        contextTypeUpperBound = TestContext::class,
-        exclusions = setOf("io.toolisticon.kotlin.generation.itest.spi.TestDataClassStrategy")
-      )
-    }.isInstanceOf(IllegalStateException::class.java)
-      .hasMessage("No serviceInstances found, configure `META-INF/services/io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpi`, and/or check your exclusions filter.")
+  fun `init is empty`() {
+    val registry = registry(
+      contextTypeUpperBound = TestContext::class,
+      exclusions = setOf("io.toolisticon.kotlin.generation.itest.spi.TestDataClassStrategy")
+    )
+
+    assertThat(registry.strategies).isEmpty()
+    assertThat(registry.processors).isEmpty()
   }
 
   @Test
   fun `use spi defined strategies and processors to generate code`() {
-    val registry = registry(contextTypeUpperBound = TestContext::class)
-    val context = TestContext(registry)
+    val list = registry()
+    val context = TestContext(KotlinCodeGenerationServiceRepository(list))
 
 
     val input = MapInput(

--- a/_itest/spi-itest/src/test/kotlin/SpiITest.kt
+++ b/_itest/spi-itest/src/test/kotlin/SpiITest.kt
@@ -4,7 +4,7 @@ import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.className
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.registry
-import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationServiceRepository
+import io.toolisticon.kotlin.generation.spi.registry.DefaultKotlinCodeGenerationServiceRegistry
 import io.toolisticon.kotlin.generation.spi.strategy.executeSingle
 import io.toolisticon.kotlin.generation.test.KotlinCodeGenerationTest.compile
 import io.toolisticon.kotlin.generation.test.callPrimaryConstructor
@@ -31,7 +31,7 @@ internal class SpiITest {
   @Test
   fun `use spi defined strategies and processors to generate code`() {
     val list = registry()
-    val context = TestContext(KotlinCodeGenerationServiceRepository(list))
+    val context = TestContext(DefaultKotlinCodeGenerationServiceRegistry(list))
 
 
     val input = MapInput(

--- a/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
+++ b/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
@@ -29,7 +29,6 @@ import io.toolisticon.kotlin.generation.poet.FormatSpecifier.asCodeBlock
 import io.toolisticon.kotlin.generation.spec.*
 import io.toolisticon.kotlin.generation.spi.*
 import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationServiceLoader
-import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationSpiList
 import io.toolisticon.kotlin.generation.spi.strategy.executeAll
 import io.toolisticon.kotlin.generation.support.SUPPRESS_MEMBER_VISIBILITY_CAN_BE_PRIVATE
 import java.util.function.Predicate
@@ -555,22 +554,6 @@ object KotlinCodeGeneration {
       classLoader: ClassLoader = defaultClassLoader(),
       filter: KotlinCodeGenerationSpiPredicate = Predicate { true }
     ) = KotlinCodeGenerationServiceLoader(classLoader)().filter(filter)
-
-    fun registry(
-      classLoader: ClassLoader = defaultClassLoader(),
-      filter: KotlinCodeGenerationSpiPredicate = Predicate { true }
-    ): KotlinCodeGenerationSpiList = KotlinCodeGenerationServiceLoader(classLoader)().filter(filter)
-
-    /**
-     * Initializes registry using spi.
-     */
-    fun registry(
-      contextTypeUpperBound: KClass<*> = Any::class,
-      classLoader: ClassLoader = defaultClassLoader(),
-      exclusions: Set<String> = emptySet()
-    ): KotlinCodeGenerationSpiList = KotlinCodeGenerationServiceLoader(classLoader = classLoader)()
-      .filter(filter.hasContextType(contextTypeUpperBound))
-      .filterNot(filter.hasNameIn(exclusions))
   }
 
   /**

--- a/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
+++ b/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
@@ -27,13 +27,12 @@ import io.toolisticon.kotlin.generation.builder.extra.*
 import io.toolisticon.kotlin.generation.builder.extra.DelegateMapValueClassSpecBuilder.Companion.DEFAULT_KEY_TYPE
 import io.toolisticon.kotlin.generation.poet.FormatSpecifier.asCodeBlock
 import io.toolisticon.kotlin.generation.spec.*
-import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationContext
-import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationContextFactory
-import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpiRegistry
-import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationStrategy
+import io.toolisticon.kotlin.generation.spi.*
 import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationServiceLoader
+import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationSpiList
 import io.toolisticon.kotlin.generation.spi.strategy.executeAll
 import io.toolisticon.kotlin.generation.support.SUPPRESS_MEMBER_VISIBILITY_CAN_BE_PRIVATE
+import java.util.function.Predicate
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
@@ -512,10 +511,50 @@ object KotlinCodeGeneration {
    */
   @Suppress("ClassName")
   object spi {
+
     /**
      * The default classLoader supplier fn.
      */
     val defaultClassLoader: () -> ClassLoader = { Thread.currentThread().contextClassLoader }
+
+    @Suppress("ClassName")
+    object filter {
+
+      val all: KotlinCodeGenerationSpiPredicate = Predicate { true }
+
+      fun hasName(name: String): KotlinCodeGenerationSpiPredicate = Predicate {
+        name == it::class.simpleName
+      }
+
+      val isStrategy: KotlinCodeGenerationSpiPredicate = Predicate {
+        it is UnboundKotlinCodeGenerationStrategy
+      }
+
+      val isProcessor: KotlinCodeGenerationSpiPredicate = Predicate {
+        it is UnboundKotlinCodeGenerationProcessor
+      }
+
+      fun hasNameIn(names: Set<String>): KotlinCodeGenerationSpiPredicate = Predicate {
+        names.contains(it::class.java.name)
+      }
+
+      fun hasContextType(contextType: KClass<*>): KotlinCodeGenerationSpiPredicate = Predicate {
+        it.contextType.isSubclassOf(contextType)
+      }
+
+      fun hasInputType(inputType: KClass<*>): KotlinCodeGenerationSpiPredicate = Predicate {
+        it.inputType.isSubclassOf(inputType)
+      }
+
+      fun hasSpecType(specType: KClass<*>): KotlinCodeGenerationSpiPredicate = Predicate {
+        it.inputType.isSubclassOf(specType)
+      }
+    }
+
+    fun registry(
+      classLoader: ClassLoader = defaultClassLoader(),
+      filter: KotlinCodeGenerationSpiPredicate = Predicate { true }
+    ): KotlinCodeGenerationSpiList = KotlinCodeGenerationServiceLoader(classLoader)().filter(filter)
 
     /**
      * Initializes registry using spi.
@@ -524,7 +563,9 @@ object KotlinCodeGeneration {
       contextTypeUpperBound: KClass<*> = Any::class,
       classLoader: ClassLoader = defaultClassLoader(),
       exclusions: Set<String> = emptySet()
-    ): KotlinCodeGenerationSpiRegistry = KotlinCodeGenerationServiceLoader(contextTypeUpperBound = contextTypeUpperBound, classLoader = classLoader, exclusions = exclusions).invoke()
+    ): KotlinCodeGenerationSpiList = KotlinCodeGenerationServiceLoader(classLoader = classLoader)()
+      .filter(filter.hasContextType(contextTypeUpperBound))
+      .filterNot(filter.hasNameIn(exclusions))
   }
 
   /**

--- a/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
+++ b/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
@@ -519,40 +519,67 @@ object KotlinCodeGeneration {
     @Suppress("ClassName")
     object filter {
 
+      /**
+       * Does not filter anything, matches all.
+       */
       val all: KotlinCodeGenerationSpiPredicate = Predicate { true }
 
+      /**
+       * Matches by name, using the simpleName of the class.
+       */
       fun hasName(name: String): KotlinCodeGenerationSpiPredicate = Predicate {
         name == it::class.simpleName
       }
 
+      /**
+       * Matches if instance is of type [UnboundKotlinCodeGenerationStrategy].
+       */
       val isStrategy: KotlinCodeGenerationSpiPredicate = Predicate {
         it is UnboundKotlinCodeGenerationStrategy
       }
 
+      /**
+       * Matches if instance is of type [UnboundKotlinCodeGenerationProcessor].
+       */
       val isProcessor: KotlinCodeGenerationSpiPredicate = Predicate {
         it is UnboundKotlinCodeGenerationProcessor
       }
 
+      /**
+       * Matches if instances has a name contained in the given set.
+       */
       fun hasNameIn(names: Set<String>): KotlinCodeGenerationSpiPredicate = Predicate {
         names.contains(it::class.java.name)
       }
 
+      /**
+       * Matches if the contextType of the instance is a subclass of the given contextType.
+       */
       fun hasContextType(contextType: KClass<*>): KotlinCodeGenerationSpiPredicate = Predicate {
         it.contextType.isSubclassOf(contextType)
       }
 
+      /**
+       * Matches if the inputType of the instance is a subclass of the given inputType.
+       */
       fun hasInputType(inputType: KClass<*>): KotlinCodeGenerationSpiPredicate = Predicate {
         it.inputType.isSubclassOf(inputType)
       }
 
+      /**
+       * Matches if the specType of the instance is a subclass of the given specType.
+       */
       fun hasSpecType(specType: KClass<*>): KotlinCodeGenerationSpiPredicate = Predicate {
         it.inputType.isSubclassOf(specType)
       }
     }
 
+    /**
+     * Load all [KotlinCodeGenerationSpi] instances from the classpath resource using the default classLoader.
+     */
     fun load(
       classLoader: ClassLoader = defaultClassLoader(),
-      filter: KotlinCodeGenerationSpiPredicate = Predicate { true }
+      filter: KotlinCodeGenerationSpiPredicate = spi.filter.all
     ) = KotlinCodeGenerationServiceLoader(classLoader)().filter(filter)
   }
 

--- a/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
+++ b/kotlin-code-generation/src/main/kotlin/KotlinCodeGeneration.kt
@@ -551,6 +551,11 @@ object KotlinCodeGeneration {
       }
     }
 
+    fun load(
+      classLoader: ClassLoader = defaultClassLoader(),
+      filter: KotlinCodeGenerationSpiPredicate = Predicate { true }
+    ) = KotlinCodeGenerationServiceLoader(classLoader)().filter(filter)
+
     fun registry(
       classLoader: ClassLoader = defaultClassLoader(),
       filter: KotlinCodeGenerationSpiPredicate = Predicate { true }

--- a/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationProcessor.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationProcessor.kt
@@ -26,6 +26,14 @@ interface KotlinCodeGenerationProcessor<CONTEXT : KotlinCodeGenerationContext<CO
    * Input is nullable because we could use processors solely based on context.
    */
   operator fun invoke(context: CONTEXT, input: INPUT, builder: BUILDER): BUILDER
+
+  /**
+   * Checks if this processor should be applied.
+   *
+   * @param context the context we are operating in
+   * @param input the concrete work item
+   * @return `true` if this processor should be applied, `false` otherwise.
+   */
   override fun test(context: CONTEXT, input: Any): Boolean = super.test(context, input)
 
   /**

--- a/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationProcessor.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationProcessor.kt
@@ -45,9 +45,3 @@ interface KotlinCodeGenerationProcessor<CONTEXT : KotlinCodeGenerationContext<CO
     builder
   }
 }
-
-/**
- * Convenience alias to reference unbound processors without repeating the `<*,*,*>`.
- */
-@ExperimentalKotlinPoetApi
-typealias UnboundKotlinCodeGenerationProcessor = KotlinCodeGenerationProcessor<*, *, *>

--- a/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationSpiRegistry.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationSpiRegistry.kt
@@ -3,7 +3,6 @@ package io.toolisticon.kotlin.generation.spi
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
-import kotlin.reflect.KClass
 
 /**
  * The registry provides access to all registered [KotlinCodeGenerationSpi] instances.
@@ -18,13 +17,6 @@ import kotlin.reflect.KClass
 @ExperimentalKotlinPoetApi
 interface KotlinCodeGenerationSpiRegistry {
   /**
-   * All spi instances define a [KotlinCodeGenerationSpi.contextType] to indicate the context
-   * they are operating on. The registries upper bound defines what contextTypes are allowed in this
-   * registry. Especially useful when dealing with context hierarchies.
-   */
-  val contextTypeUpperBound: KClass<*>
-
-  /**
    * All registered [KotlinCodeGenerationStrategy] instances, wrapped in a [KotlinCodeGenerationStrategyList].
    * Must not be empty.
    */
@@ -35,5 +27,5 @@ interface KotlinCodeGenerationSpiRegistry {
    * Might be empty.
    */
   val processors: KotlinCodeGenerationProcessorList
-
 }
+

--- a/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationSpiRegistry.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationSpiRegistry.kt
@@ -28,4 +28,3 @@ interface KotlinCodeGenerationSpiRegistry {
    */
   val processors: KotlinCodeGenerationProcessorList
 }
-

--- a/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationStrategy.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationStrategy.kt
@@ -32,6 +32,14 @@ interface KotlinCodeGenerationStrategy<CONTEXT : KotlinCodeGenerationContext<CON
    * @return the generated spec
    */
   operator fun invoke(context: CONTEXT, input: INPUT): SPEC
+
+  /**
+   * Checks if this strategy should be applied.
+   *
+   * @param context the context we are operating in
+   * @param input the concrete work item
+   * @return `true` if this strategy should be applied, `false` otherwise.
+   */
   override fun test(context: CONTEXT, input: Any): Boolean = super.test(context, input)
 
   /**

--- a/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationStrategy.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/KotlinCodeGenerationStrategy.kt
@@ -49,9 +49,3 @@ interface KotlinCodeGenerationStrategy<CONTEXT : KotlinCodeGenerationContext<CON
     null
   }
 }
-
-/**
- * Convenience alias to reference unbound strategies without repeating the `<*,*,*>`.
- */
-@ExperimentalKotlinPoetApi
-typealias UnboundKotlinCodeGenerationStrategy = KotlinCodeGenerationStrategy<*, *, *>

--- a/kotlin-code-generation/src/main/kotlin/spi/_types.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/_types.kt
@@ -34,7 +34,9 @@ typealias UnboundKotlinCodeGenerationStrategy = KotlinCodeGenerationStrategy<*, 
 @ExperimentalKotlinPoetApi
 typealias UnboundKotlinCodeGenerationProcessor = KotlinCodeGenerationProcessor<*, *, *>
 
-
+/**
+ * Convenience alias for a [Predicate] without repeating the `<*,*,*>`.
+ */
 @ExperimentalKotlinPoetApi
 typealias KotlinCodeGenerationSpiPredicate = Predicate<UnboundKotlinCodeGenerationSpi>
 

--- a/kotlin-code-generation/src/main/kotlin/spi/_types.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/_types.kt
@@ -1,6 +1,40 @@
 package io.toolisticon.kotlin.generation.spi
 
+import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
+import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationSpiList
+import java.util.function.Predicate
+import java.util.function.Supplier
+
 /**
  * Use to express that a processor does not work on an input loop variable.
  */
 data object EmptyInput
+
+@OptIn(ExperimentalKotlinPoetApi::class)
+fun interface KotlinCodeGenerationSpiListSupplier : Supplier<KotlinCodeGenerationSpiList>, () -> KotlinCodeGenerationSpiList {
+  override fun get(): KotlinCodeGenerationSpiList = invoke()
+  override fun invoke(): KotlinCodeGenerationSpiList
+}
+
+/**
+ * Convenience alias to reference unbound strategies without repeating the `<*,*,*>`.
+ */
+@ExperimentalKotlinPoetApi
+typealias UnboundKotlinCodeGenerationSpi = KotlinCodeGenerationSpi<*, *>
+
+/**
+ * Convenience alias to reference unbound strategies without repeating the `<*,*,*>`.
+ */
+@ExperimentalKotlinPoetApi
+typealias UnboundKotlinCodeGenerationStrategy = KotlinCodeGenerationStrategy<*, *, *>
+
+/**
+ * Convenience alias to reference unbound processors without repeating the `<*,*,*>`.
+ */
+@ExperimentalKotlinPoetApi
+typealias UnboundKotlinCodeGenerationProcessor = KotlinCodeGenerationProcessor<*, *, *>
+
+
+@ExperimentalKotlinPoetApi
+typealias KotlinCodeGenerationSpiPredicate = Predicate<UnboundKotlinCodeGenerationSpi>
+

--- a/kotlin-code-generation/src/main/kotlin/spi/processor/KotlinCodeGenerationProcessorList.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/processor/KotlinCodeGenerationProcessorList.kt
@@ -10,8 +10,8 @@ import kotlin.reflect.KClass
  * Wraps list of [KotlinCodeGenerationProcessor] instances. Used to provide additional functionalities.
  */
 @ExperimentalKotlinPoetApi
-@JvmInline
-value class KotlinCodeGenerationProcessorList(
+@Suppress("JavaDefaultMethodsNotOverriddenByDelegation")
+data class KotlinCodeGenerationProcessorList(
   @PublishedApi
   internal val list: List<UnboundKotlinCodeGenerationProcessor>
 ) : List<UnboundKotlinCodeGenerationProcessor> by list {
@@ -36,10 +36,8 @@ value class KotlinCodeGenerationProcessorList(
    */
   inline fun <reified PROCESSOR : KotlinCodeGenerationProcessor<CONTEXT, INPUT, SPEC>, CONTEXT : KotlinCodeGenerationContext<CONTEXT>, INPUT : Any, SPEC : Any> filter() = filter(PROCESSOR::class)
 
-
   override fun toString(): String = "KotlinCodeGenerationProcessorList(processors=${list.map { it.name }})"
 }
-
 
 @ExperimentalKotlinPoetApi
 fun <PROCESSOR : KotlinCodeGenerationProcessor<CONTEXT, INPUT, BUILDER>, CONTEXT : KotlinCodeGenerationContext<CONTEXT>, INPUT : Any, BUILDER : Any> List<PROCESSOR>.executeSingle(

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/DefaultKotlinCodeGenerationServiceRegistry.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/DefaultKotlinCodeGenerationServiceRegistry.kt
@@ -3,6 +3,7 @@ package io.toolisticon.kotlin.generation.spi.registry
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationProcessor
+import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpiPredicate
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpiRegistry
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationStrategy
 import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
@@ -16,7 +17,7 @@ import java.util.*
  * or short by [io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.registry].
  */
 @ExperimentalKotlinPoetApi
-data class KotlinCodeGenerationServiceRepository(
+data class DefaultKotlinCodeGenerationServiceRegistry(
   override val processors: KotlinCodeGenerationProcessorList = KotlinCodeGenerationProcessorList(),
   override val strategies: KotlinCodeGenerationStrategyList = KotlinCodeGenerationStrategyList(),
 ) : KotlinCodeGenerationSpiRegistry {
@@ -25,6 +26,8 @@ data class KotlinCodeGenerationServiceRepository(
     processors = spi.processors,
     strategies = spi.strategies,
   )
+
+  constructor(spi: KotlinCodeGenerationSpiList, filter: KotlinCodeGenerationSpiPredicate) : this(spi.filter(filter))
 
   private val logger = KotlinLogging.logger {}
 

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationServiceLoader.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationServiceLoader.kt
@@ -3,50 +3,24 @@ package io.toolisticon.kotlin.generation.spi.registry
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpi
+import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpiListSupplier
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpiRegistry
-import io.toolisticon.kotlin.generation.spi.UnboundKotlinCodeGenerationProcessor
-import io.toolisticon.kotlin.generation.spi.UnboundKotlinCodeGenerationStrategy
-import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
-import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
 import java.util.*
-import kotlin.reflect.KClass
-import kotlin.reflect.full.isSubclassOf
 
 /**
  * Provides [KotlinCodeGenerationSpiRegistry] using [ServiceLoader].
  *
  * To avoid too many ´META-INF/services` declarations, all [KotlinCodeGenerationSpi] instances are declared in
  * one single resource. The loading mechanism automatically sorts them into strategies and processors.
+ *
+ * @since 0.2.0: does not filter on context type anymore, so all services are accepted regardless of their context type.
  */
 @ExperimentalKotlinPoetApi
 class KotlinCodeGenerationServiceLoader(
-  val contextTypeUpperBound: KClass<*> = Any::class,
-  val classLoader: ClassLoader = KotlinCodeGeneration.spi.defaultClassLoader(),
-  val exclusions: Set<String> = emptySet(),
-  // If true, the contextTypeUpperBound is ignored, and all services are accepted regardless of their context type.
-  val ignoreContext: Boolean = false
-) : () -> KotlinCodeGenerationSpiRegistry {
+  val classLoader: ClassLoader = KotlinCodeGeneration.spi.defaultClassLoader()
+) : KotlinCodeGenerationSpiListSupplier {
 
-  override fun invoke(): KotlinCodeGenerationSpiRegistry {
-    val serviceInstances: List<KotlinCodeGenerationSpi<*, *>> = ServiceLoader.load(KotlinCodeGenerationSpi::class.java, classLoader).toList()
-      .filter { it.contextType.isSubclassOf(contextTypeUpperBound) }
-      .filterNot { exclusions.contains(it::class.java.name) }
-    check(serviceInstances.isNotEmpty()) { "No serviceInstances found, configure `${KotlinCodeGenerationSpi.metaInfServices}`, and/or check your exclusions filter." }
-
-    if (!ignoreContext) {
-      val withIllegalContextType = serviceInstances.filterNot { it.contextType.isSubclassOf(contextTypeUpperBound) }
-
-      require(withIllegalContextType.isEmpty()) {
-        "All declarations of type `${KotlinCodeGenerationSpi.metaInfServices}` " +
-          "must be a subclass of contextType=$contextTypeUpperBound, but " +
-          "found ${withIllegalContextType.joinToString(", ")}."
-      }
-    }
-
-    return KotlinCodeGenerationServiceRepository(
-      contextTypeUpperBound = contextTypeUpperBound,
-      strategies = KotlinCodeGenerationStrategyList(serviceInstances.filterIsInstance<UnboundKotlinCodeGenerationStrategy>()),
-      processors = KotlinCodeGenerationProcessorList(serviceInstances.filterIsInstance<UnboundKotlinCodeGenerationProcessor>())
-    )
-  }
+  override fun invoke(): KotlinCodeGenerationSpiList = KotlinCodeGenerationSpiList(
+    ServiceLoader.load(KotlinCodeGenerationSpi::class.java, classLoader).toList()
+  )
 }

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationServiceLoader.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationServiceLoader.kt
@@ -8,7 +8,7 @@ import io.toolisticon.kotlin.generation.spi.UnboundKotlinCodeGenerationProcessor
 import io.toolisticon.kotlin.generation.spi.UnboundKotlinCodeGenerationStrategy
 import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
-import java.util.ServiceLoader
+import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
@@ -22,20 +22,25 @@ import kotlin.reflect.full.isSubclassOf
 class KotlinCodeGenerationServiceLoader(
   val contextTypeUpperBound: KClass<*> = Any::class,
   val classLoader: ClassLoader = KotlinCodeGeneration.spi.defaultClassLoader(),
-  val exclusions: Set<String> = emptySet()
+  val exclusions: Set<String> = emptySet(),
+  // If true, the contextTypeUpperBound is ignored, and all services are accepted regardless of their context type.
+  val ignoreContext: Boolean = false
 ) : () -> KotlinCodeGenerationSpiRegistry {
 
   override fun invoke(): KotlinCodeGenerationSpiRegistry {
     val serviceInstances: List<KotlinCodeGenerationSpi<*, *>> = ServiceLoader.load(KotlinCodeGenerationSpi::class.java, classLoader).toList()
+      .filter { it.contextType.isSubclassOf(contextTypeUpperBound) }
       .filterNot { exclusions.contains(it::class.java.name) }
     check(serviceInstances.isNotEmpty()) { "No serviceInstances found, configure `${KotlinCodeGenerationSpi.metaInfServices}`, and/or check your exclusions filter." }
 
-    val withIllegalContextType = serviceInstances.filterNot { it.contextType.isSubclassOf(contextTypeUpperBound) }
+    if (!ignoreContext) {
+      val withIllegalContextType = serviceInstances.filterNot { it.contextType.isSubclassOf(contextTypeUpperBound) }
 
-    require(withIllegalContextType.isEmpty()) {
-      "All declarations of type `${KotlinCodeGenerationSpi.metaInfServices}` " +
-        "must be a subclass of contextType=$contextTypeUpperBound, but " +
-        "found ${withIllegalContextType.joinToString(", ")}."
+      require(withIllegalContextType.isEmpty()) {
+        "All declarations of type `${KotlinCodeGenerationSpi.metaInfServices}` " +
+          "must be a subclass of contextType=$contextTypeUpperBound, but " +
+          "found ${withIllegalContextType.joinToString(", ")}."
+      }
     }
 
     return KotlinCodeGenerationServiceRepository(

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationServiceRepository.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationServiceRepository.kt
@@ -2,14 +2,12 @@ package io.toolisticon.kotlin.generation.spi.registry
 
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.toolisticon.kotlin.generation.KotlinCodeGeneration
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationProcessor
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationSpiRegistry
 import io.toolisticon.kotlin.generation.spi.KotlinCodeGenerationStrategy
 import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
 import java.util.*
-import kotlin.reflect.KClass
 
 /**
  * Holds all implementation instances of [KotlinCodeGenerationStrategy] and [KotlinCodeGenerationProcessor].
@@ -18,21 +16,15 @@ import kotlin.reflect.KClass
  * or short by [io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.registry].
  */
 @ExperimentalKotlinPoetApi
-class KotlinCodeGenerationServiceRepository(
-  override val contextTypeUpperBound: KClass<*>,
+data class KotlinCodeGenerationServiceRepository(
   override val processors: KotlinCodeGenerationProcessorList = KotlinCodeGenerationProcessorList(),
   override val strategies: KotlinCodeGenerationStrategyList = KotlinCodeGenerationStrategyList(),
 ) : KotlinCodeGenerationSpiRegistry {
-  companion object {
 
-    fun load(
-      contextTypeUpperBound: KClass<*>,
-      classLoader: ClassLoader = KotlinCodeGeneration.spi.defaultClassLoader(),
-      exclusions: Set<String> = emptySet()
-    ): KotlinCodeGenerationSpiRegistry {
-      return KotlinCodeGenerationServiceLoader(contextTypeUpperBound, classLoader, exclusions)()
-    }
-  }
+  constructor(spi: KotlinCodeGenerationSpiList) : this(
+    processors = spi.processors,
+    strategies = spi.strategies,
+  )
 
   private val logger = KotlinLogging.logger {}
 
@@ -44,7 +36,6 @@ class KotlinCodeGenerationServiceRepository(
   }
 
   override fun toString(): String = "${this::class.simpleName}(" +
-    "contextType=$contextTypeUpperBound, " +
     "strategies=${strategies}, " +
     "processors=${processors})"
 }

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationSpiList.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationSpiList.kt
@@ -1,0 +1,34 @@
+package io.toolisticon.kotlin.generation.spi.registry
+
+import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
+import io.toolisticon.kotlin.generation.spi.*
+import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
+import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
+
+/**
+ * A list of [UnboundKotlinCodeGenerationSpi] that implements the [KotlinCodeGenerationSpiRegistry] interface.
+ */
+@ExperimentalKotlinPoetApi
+@Suppress("JavaDefaultMethodsNotOverriddenByDelegation")
+data class KotlinCodeGenerationSpiList(private val list: List<UnboundKotlinCodeGenerationSpi>) : List<UnboundKotlinCodeGenerationSpi> by list {
+
+  constructor(vararg strategy: UnboundKotlinCodeGenerationSpi) : this(strategy.toList())
+
+  val strategies: KotlinCodeGenerationStrategyList by lazy {
+    KotlinCodeGenerationStrategyList(list.filterIsInstance<UnboundKotlinCodeGenerationStrategy>())
+  }
+
+  val processors: KotlinCodeGenerationProcessorList by lazy {
+    KotlinCodeGenerationProcessorList(list.filterIsInstance<UnboundKotlinCodeGenerationProcessor>())
+  }
+
+  fun filter(filter: KotlinCodeGenerationSpiPredicate): KotlinCodeGenerationSpiList = copy(
+    list = list.filter { filter.test(it) }
+  )
+
+  fun filterNot(filter: KotlinCodeGenerationSpiPredicate): KotlinCodeGenerationSpiList = copy(
+    list = list.filter { !filter.test(it) }
+  )
+
+  override fun toString(): String = "KotlinCodeGenerationSpiList(list=${list.map { it.name }})"
+}

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationSpiList.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationSpiList.kt
@@ -21,24 +21,47 @@ data class KotlinCodeGenerationSpiList(private val list: List<UnboundKotlinCodeG
    */
   constructor(vararg strategy: UnboundKotlinCodeGenerationSpi) : this(strategy.toList())
 
+  /**
+   * Gives all strategies from this list.
+   */
   val strategies: KotlinCodeGenerationStrategyList by lazy {
     KotlinCodeGenerationStrategyList(list.filterIsInstance<UnboundKotlinCodeGenerationStrategy>())
   }
 
+  /**
+   * Gives all processors from this list.
+   */
   val processors: KotlinCodeGenerationProcessorList by lazy {
     KotlinCodeGenerationProcessorList(list.filterIsInstance<UnboundKotlinCodeGenerationProcessor>())
   }
 
+  /**
+   * Returns a new [KotlinCodeGenerationSpiList] containing only the strategies and processors that match the given predicate.
+   *
+   * @param filter the predicate to filter the strategies and processors.
+   * @return a new [KotlinCodeGenerationSpiList] containing only the matching strategies and processors.
+   */
   fun filter(filter: KotlinCodeGenerationSpiPredicate): KotlinCodeGenerationSpiList = copy(
     list = list.filter { filter.test(it) }
   )
 
+  /**
+   * Returns a new [KotlinCodeGenerationSpiList] containing only the strategies and processors that do _not_ match the given predicate.
+   *
+   * @param filter the predicate to filter the strategies and processors.
+   * @return a new [KotlinCodeGenerationSpiList] containing only the non-matching strategies and processors.
+   */
   fun filterNot(filter: KotlinCodeGenerationSpiPredicate): KotlinCodeGenerationSpiList = copy(
     list = list.filter { !filter.test(it) }
   )
 
   override fun toString(): String = "KotlinCodeGenerationSpiList(list=${list.map { it.name }})"
 
+  /**
+   * Creates a [KotlinCodeGenerationSpiRegistry] from this list.
+   *
+   * @return a [KotlinCodeGenerationSpiRegistry] containing the strategies and processors from this list.
+   */
   fun registry() : KotlinCodeGenerationSpiRegistry = DefaultKotlinCodeGenerationServiceRegistry(
     strategies = strategies,
     processors = processors

--- a/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationSpiList.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/registry/KotlinCodeGenerationSpiList.kt
@@ -7,11 +7,18 @@ import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrateg
 
 /**
  * A list of [UnboundKotlinCodeGenerationSpi] that implements the [KotlinCodeGenerationSpiRegistry] interface.
+ *
+ * These are loaded via SPI using [java.util.ServiceLoader], implemented via [KotlinCodeGenerationSpiListSupplier].
  */
 @ExperimentalKotlinPoetApi
 @Suppress("JavaDefaultMethodsNotOverriddenByDelegation")
 data class KotlinCodeGenerationSpiList(private val list: List<UnboundKotlinCodeGenerationSpi>) : List<UnboundKotlinCodeGenerationSpi> by list {
 
+  /**
+   * Creates a [KotlinCodeGenerationSpiList] from the given strategies and processors.
+   *
+   * @param strategy the strategies to include in the list.
+   */
   constructor(vararg strategy: UnboundKotlinCodeGenerationSpi) : this(strategy.toList())
 
   val strategies: KotlinCodeGenerationStrategyList by lazy {
@@ -31,4 +38,9 @@ data class KotlinCodeGenerationSpiList(private val list: List<UnboundKotlinCodeG
   )
 
   override fun toString(): String = "KotlinCodeGenerationSpiList(list=${list.map { it.name }})"
+
+  fun registry() : KotlinCodeGenerationSpiRegistry = DefaultKotlinCodeGenerationServiceRegistry(
+    strategies = strategies,
+    processors = processors
+  )
 }

--- a/kotlin-code-generation/src/main/kotlin/spi/strategy/KotlinCodeGenerationStrategyList.kt
+++ b/kotlin-code-generation/src/main/kotlin/spi/strategy/KotlinCodeGenerationStrategyList.kt
@@ -10,8 +10,8 @@ import kotlin.reflect.KClass
  * Wraps list of [KotlinCodeGenerationStrategy] instances. Used to provide additional functionalities.
  */
 @ExperimentalKotlinPoetApi
-@JvmInline
-value class KotlinCodeGenerationStrategyList(
+@Suppress("JavaDefaultMethodsNotOverriddenByDelegation")
+data class KotlinCodeGenerationStrategyList(
   @PublishedApi
   internal val list: List<UnboundKotlinCodeGenerationStrategy>
 ) : List<UnboundKotlinCodeGenerationStrategy> by list {
@@ -37,6 +37,7 @@ value class KotlinCodeGenerationStrategyList(
   inline fun <reified STRATEGY : KotlinCodeGenerationStrategy<CONTEXT, INPUT, SPEC>, CONTEXT : KotlinCodeGenerationContext<CONTEXT>, INPUT : Any, SPEC : Any> filter() = filter(STRATEGY::class)
 
   override fun toString(): String = "KotlinCodeGenerationStrategyList(strategies=${list.map { it.name }})"
+
 }
 
 @ExperimentalKotlinPoetApi

--- a/kotlin-code-generation/src/test/kotlin/TestFixtures.kt
+++ b/kotlin-code-generation/src/test/kotlin/TestFixtures.kt
@@ -1,4 +1,3 @@
-
 package io.toolisticon.kotlin.generation
 
 import com.squareup.kotlinpoet.ClassName
@@ -101,7 +100,6 @@ object TestFixtures {
     }
   }
 
-
   object SpiFixtures {
 
     data class InputA(
@@ -129,17 +127,14 @@ object TestFixtures {
       contextType = EmptyContext::class, inputType = InputB::class
     )
 
-
     object EmptyContext : KotlinCodeGenerationContext<EmptyContext> {
       override val contextType = EmptyContext::class
       override val registry = EmptyRegistry
     }
 
     object EmptyRegistry : KotlinCodeGenerationSpiRegistry {
-      override val contextTypeUpperBound = Any::class
       override val strategies: KotlinCodeGenerationStrategyList = KotlinCodeGenerationStrategyList()
       override val processors: KotlinCodeGenerationProcessorList = KotlinCodeGenerationProcessorList()
     }
   }
-
 }

--- a/kotlin-code-generation/src/test/kotlin/_test/MutableSpiRegistry.kt
+++ b/kotlin-code-generation/src/test/kotlin/_test/MutableSpiRegistry.kt
@@ -1,4 +1,3 @@
-
 package io.toolisticon.kotlin.generation._test
 
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
@@ -7,15 +6,12 @@ import io.toolisticon.kotlin.generation.spi.UnboundKotlinCodeGenerationProcessor
 import io.toolisticon.kotlin.generation.spi.UnboundKotlinCodeGenerationStrategy
 import io.toolisticon.kotlin.generation.spi.processor.KotlinCodeGenerationProcessorList
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
-import kotlin.reflect.KClass
 
 @OptIn(ExperimentalKotlinPoetApi::class)
 class MutableSpiRegistry(
   val strategyList: MutableList<UnboundKotlinCodeGenerationStrategy> = mutableListOf(),
   val processorList: MutableList<UnboundKotlinCodeGenerationProcessor> = mutableListOf(),
 ) : KotlinCodeGenerationSpiRegistry {
-  override val contextTypeUpperBound: KClass<*> = TestContext::class
-
   override val strategies: KotlinCodeGenerationStrategyList get() = KotlinCodeGenerationStrategyList(strategyList)
   override val processors: KotlinCodeGenerationProcessorList get() = KotlinCodeGenerationProcessorList(processorList)
 }

--- a/kotlin-code-generation/src/test/kotlin/spi/KotlinCodeGenerationServiceRepositoryTest.kt
+++ b/kotlin-code-generation/src/test/kotlin/spi/KotlinCodeGenerationServiceRepositoryTest.kt
@@ -32,14 +32,6 @@ internal class KotlinCodeGenerationServiceRepositoryTest {
 
   }
 
-
-  @Test
-  fun `create registry from spi instances`() {
-    val registry = KotlinCodeGenerationServiceRepository(contextTypeUpperBound = TestContext::class, strategies = KotlinCodeGenerationStrategyList(FooDataClassStrategy()))
-
-    println(registry)
-  }
-
   object SealedSuperContext {
 
     sealed interface TestType {
@@ -74,7 +66,6 @@ internal class KotlinCodeGenerationServiceRepositoryTest {
   @Test
   fun `initialize with sealed super context`() {
     val registry = KotlinCodeGenerationServiceRepository(
-      contextTypeUpperBound = SealedSuperContext.SuperContext::class,
       strategies = KotlinCodeGenerationStrategyList(SealedSuperContext.LongDataClassStrategy(), SealedSuperContext.StringDataClassStrategy())
     )
 

--- a/kotlin-code-generation/src/test/kotlin/spi/KotlinCodeGenerationServiceRepositoryTest.kt
+++ b/kotlin-code-generation/src/test/kotlin/spi/KotlinCodeGenerationServiceRepositoryTest.kt
@@ -4,7 +4,7 @@ import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration
 import io.toolisticon.kotlin.generation.spec.KotlinDataClassSpec
 import io.toolisticon.kotlin.generation.spi.context.KotlinCodeGenerationContextBase
-import io.toolisticon.kotlin.generation.spi.registry.KotlinCodeGenerationServiceRepository
+import io.toolisticon.kotlin.generation.spi.registry.DefaultKotlinCodeGenerationServiceRegistry
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinCodeGenerationStrategyList
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinDataClassSpecStrategy
 import org.assertj.core.api.Assertions.assertThat
@@ -65,7 +65,7 @@ internal class KotlinCodeGenerationServiceRepositoryTest {
 
   @Test
   fun `initialize with sealed super context`() {
-    val registry = KotlinCodeGenerationServiceRepository(
+    val registry = DefaultKotlinCodeGenerationServiceRegistry(
       strategies = KotlinCodeGenerationStrategyList(SealedSuperContext.LongDataClassStrategy(), SealedSuperContext.StringDataClassStrategy())
     )
 


### PR DESCRIPTION
We need to build multiple contexts using SPI so we could not keep the check for upper context bound.
fixes #74